### PR TITLE
Add httptest.ResponseRecorder to typecheck on WriteResponse

### DIFF
--- a/adapt.go
+++ b/adapt.go
@@ -136,7 +136,7 @@ func Process(agp EventParser, h http.Handler) interface{} {
 
 func WriteResponse(w http.ResponseWriter, i interface{}, isBase64 bool) (int, error) {
 	t := reflect.TypeOf(w).String()
-	if t == "*http.response" { //dirty hack to get internal type
+	if t == "*http.response" || t == "*httptest.ResponseRecorder" { //dirty hack to get internal type
 		switch i.(type) {
 		case []byte:
 			return w.Write(i.([]byte))


### PR DESCRIPTION
When writing unit tests against a handler using `httptest.NewRecorder()`, `agw.WriteResponse` will return nothing, as the hardcoded [typecheck](https://github.com/davyzhang/agw/blob/master/adapt.go#L139) will fail since an object of type `*httptest.ResponseRecorder` is passed as `w`.

For example, a unit test might include:
```
	rr := httptest.NewRecorder()
	handler := http.HandlerFunc(SomeHandler)
	handler.ServeHTTP(rr, req)
```

`SomeHandler` might look like:
```
func SomeHandler(w http.ResponseWriter, r *http.Request) {
	res := struct{
		Message string `json:"message"`
	}{
		Message: "Request successful.",
	}

	sendJson(w, http.StatusOK, res)
}

func sendJson(w http.ResponseWriter, status int, payload interface{}) {
	response, err := json.Marshal(payload)
	if err != nil {
		w.WriteHeader(http.StatusInternalServerError)
		agw.WriteResponse(w, []byte(err.Error()), false)
	}
	w.WriteHeader(status)
	agw.WriteResponse(w, []byte(response), false)
}
```

As of now, `rr.Body.String()` will return an empty string, since the [type of `w`](https://github.com/davyzhang/agw/blob/master/adapt.go#L138) is neither `*http.response` nor `*agw.LPResponse`. To support this use case, we should also check for `*httptest.ResponseRecorder` to support unit testing.