### PR TITLE
Getters for LPPresponse

### DIFF
--- a/adapt.go
+++ b/adapt.go
@@ -154,3 +154,15 @@ func WriteResponse(w http.ResponseWriter, i interface{}, isBase64 bool) (int, er
 	}
 	return 0, nil
 }
+
+func (lpr *LPResponse) Status() int {
+	return lpr.status
+}
+
+func (lpr *LPResponse) Body() interface{} {
+	return lpr.body
+}
+
+func (lpr *LPResponse) Headers() http.Header {
+	return lpr.header
+}


### PR DESCRIPTION
Hi, 
I've added these getters to be able to log response in opentelemetry middleware.
Example: 

			next.ServeHTTP(w, r)
			lppResponse, ok := w.(*agw.LPResponse)
			if ok {
				attrs := semconv.HTTPAttributesFromHTTPStatusCode(lppResponse.Status())
				spanStatus, spanMessage := semconv.SpanStatusFromHTTPStatusCode(lppResponse.Status())
				span.SetAttributes(attrs...)
				span.SetStatus(spanStatus, spanMessage)
			}

